### PR TITLE
Add Puppeteer login script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # consultaCausas
 Aplicacion para consultar causas y no olvidarse ninguna
+
+## Scripts
+
+### Login y descarga de notificaciones
+
+Instalar dependencias (requiere internet):
+
+```bash
+npm install
+```
+
+Ejecutar el proceso de login para todas las cuentas definidas en `accounts.json`:
+
+```bash
+node scripts/pjnLogin.js
+```
+
+El script guarda las notificaciones nuevas y registra el acceso de cada abogado en `data.db`.

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ Ejecutar el proceso de login para todas las cuentas definidas en `accounts.json`
 node scripts/pjnLogin.js
 ```
 
-El script guarda las notificaciones nuevas y registra el acceso de cada abogado en `data.db`.
+El script guarda las notificaciones nuevas y registra el acceso de cada abogado en la base de datos Postgres configurada en `scripts/pjnLogin.js`.
+Por defecto se conecta al servidor `192.168.1.56:5433` usando la base `PJN` y el usuario `postgres`.

--- a/accounts.json
+++ b/accounts.json
@@ -1,0 +1,10 @@
+[
+  {
+    "username": "lawyer1",
+    "password": "secret1"
+  },
+  {
+    "username": "lawyer2",
+    "password": "secret2"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "consultacausas",
+  "version": "1.0.0",
+  "description": "Aplicacion para consultar causas y no olvidarse ninguna",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "puppeteer": "^21.3.8",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "type": "commonjs",
   "dependencies": {
     "puppeteer": "^21.3.8",
-    "sqlite3": "^5.1.6"
+    "pg": "^8.11.3"
   }
 }

--- a/scripts/pjnLogin.js
+++ b/scripts/pjnLogin.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+const sqlite3 = require('sqlite3').verbose();
+
+const ACCOUNTS_FILE = path.join(__dirname, '../accounts.json');
+const DB_PATH = path.join(__dirname, '../data.db');
+
+async function loadAccounts() {
+  const data = fs.readFileSync(ACCOUNTS_FILE, 'utf8');
+  return JSON.parse(data);
+}
+
+function initDb() {
+  const db = new sqlite3.Database(DB_PATH);
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      lawyer TEXT,
+      notification TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+    db.run(`CREATE TABLE IF NOT EXISTS access_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      lawyer TEXT,
+      access_time DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+  });
+  return db;
+}
+
+async function fetchNotifications(page) {
+  return await page.evaluate(() => {
+    return Array.from(document.querySelectorAll('.notification'))
+      .map(el => el.innerText.trim())
+      .filter(Boolean);
+  });
+}
+
+async function loginAndCheck(account, db, browser) {
+  const page = await browser.newPage();
+  console.log(`Logging in as ${account.username}`);
+  await page.goto('https://example.com/login');
+  await page.type('#username', account.username);
+  await page.type('#password', account.password);
+  await page.click('#login');
+  await page.waitForNavigation();
+  db.run('INSERT INTO access_log (lawyer) VALUES (?)', [account.username]);
+  const notes = await fetchNotifications(page);
+  for (const note of notes) {
+    await new Promise((resolve, reject) => {
+      db.get('SELECT id FROM notifications WHERE lawyer=? AND notification=?', [account.username, note], (err, row) => {
+        if (err) return reject(err);
+        if (!row) {
+          db.run('INSERT INTO notifications (lawyer, notification) VALUES (?, ?)', [account.username, note]);
+          console.log('New notification saved:', note);
+        }
+        resolve();
+      });
+    });
+  }
+  await page.close();
+}
+
+(async () => {
+  const accounts = await loadAccounts();
+  const db = initDb();
+  const browser = await puppeteer.launch();
+  for (const acc of accounts) {
+    try {
+      await loginAndCheck(acc, db, browser);
+    } catch (err) {
+      console.error('Error processing account', acc.username, err);
+    }
+  }
+  await browser.close();
+  db.close();
+})();

--- a/scripts/pjnLogin.js
+++ b/scripts/pjnLogin.js
@@ -1,32 +1,36 @@
 const fs = require('fs');
 const path = require('path');
 const puppeteer = require('puppeteer');
-const sqlite3 = require('sqlite3').verbose();
+const { Client } = require('pg');
 
 const ACCOUNTS_FILE = path.join(__dirname, '../accounts.json');
-const DB_PATH = path.join(__dirname, '../data.db');
 
 async function loadAccounts() {
   const data = fs.readFileSync(ACCOUNTS_FILE, 'utf8');
   return JSON.parse(data);
 }
 
-function initDb() {
-  const db = new sqlite3.Database(DB_PATH);
-  db.serialize(() => {
-    db.run(`CREATE TABLE IF NOT EXISTS notifications (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      lawyer TEXT,
-      notification TEXT,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-    )`);
-    db.run(`CREATE TABLE IF NOT EXISTS access_log (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      lawyer TEXT,
-      access_time DATETIME DEFAULT CURRENT_TIMESTAMP
-    )`);
+async function initDb() {
+  const client = new Client({
+    host: '192.168.1.56',
+    port: 5433,
+    database: 'PJN',
+    user: 'postgres',
+    password: 'solari'
   });
-  return db;
+  await client.connect();
+  await client.query(`CREATE TABLE IF NOT EXISTS notifications (
+    id SERIAL PRIMARY KEY,
+    lawyer TEXT,
+    notification TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`);
+  await client.query(`CREATE TABLE IF NOT EXISTS access_log (
+    id SERIAL PRIMARY KEY,
+    lawyer TEXT,
+    access_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`);
+  return client;
 }
 
 async function fetchNotifications(page) {
@@ -45,26 +49,21 @@ async function loginAndCheck(account, db, browser) {
   await page.type('#password', account.password);
   await page.click('#login');
   await page.waitForNavigation();
-  db.run('INSERT INTO access_log (lawyer) VALUES (?)', [account.username]);
+  await db.query('INSERT INTO access_log (lawyer) VALUES ($1)', [account.username]);
   const notes = await fetchNotifications(page);
   for (const note of notes) {
-    await new Promise((resolve, reject) => {
-      db.get('SELECT id FROM notifications WHERE lawyer=? AND notification=?', [account.username, note], (err, row) => {
-        if (err) return reject(err);
-        if (!row) {
-          db.run('INSERT INTO notifications (lawyer, notification) VALUES (?, ?)', [account.username, note]);
-          console.log('New notification saved:', note);
-        }
-        resolve();
-      });
-    });
+    const res = await db.query('SELECT id FROM notifications WHERE lawyer=$1 AND notification=$2', [account.username, note]);
+    if (res.rowCount === 0) {
+      await db.query('INSERT INTO notifications (lawyer, notification) VALUES ($1, $2)', [account.username, note]);
+      console.log('New notification saved:', note);
+    }
   }
   await page.close();
 }
 
 (async () => {
   const accounts = await loadAccounts();
-  const db = initDb();
+  const db = await initDb();
   const browser = await puppeteer.launch();
   for (const acc of accounts) {
     try {
@@ -74,5 +73,5 @@ async function loginAndCheck(account, db, browser) {
     }
   }
   await browser.close();
-  db.close();
+  await db.end();
 })();


### PR DESCRIPTION
## Summary
- initialize npm project and declare dependencies
- add example accounts file
- implement `scripts/pjnLogin.js` using Puppeteer and SQLite
- document usage in README

## Testing
- `node scripts/pjnLogin.js` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68602da9cb00832aafdaaffbcfaeec7e